### PR TITLE
Update README for SOAP API 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,71 @@ class ShipmentRequestService
     }
     
     /**
+     * @param \DateTimeInterface $shipTimestamp
+     * @param ContactInfoType    $sender
+     * @param ContactInfoType    $recipient
+     * @param ShipmentRequest    $shipmentRequest
+     * @param string|null        $restrictToServiceType
+     *
+     * @return \DHL\Express\Webservice\ShipmentDetailType
+     */
+    public function createShipping(\DateTimeInterface $shipTimestamp, ContactInfoType $sender, ContactInfoType $recipient, ShipmentRequest $shipmentRequest, $restrictToServiceType = null)
+    {
+        $webservice = $this->prepareWebservice();
+
+        $shipmentInfo = new ShipmentInfoType(
+            DropOffType::REQUEST_COURIER,
+            $this->calculateShippingType($shipmentRequest),
+            ShipmentInfoType::CURRENCY_EUR,
+            UnitOfMeasurement::SI
+        );
+
+        $shipmentInfo->setAccount($this->accountNumber);
+
+        $internationalDetail = new InternationDetailType(new CommoditiesType('Keine Angabe'));
+        $internationalDetail->setContent(Content::DOCUMENTS);
+
+        $requestedShipment = new RequestedShipmentType(
+            $shipmentInfo,
+            sprintf('%sT%s GMT+01:00', $shipTimestamp->format('Y-m-d'), $shipTimestamp->format('H:i:s')),
+            PaymentInfo::DDP,
+            $internationalDetail,
+            new ShipType($sender, $recipient),
+            new docTypeRef_PackagesType(
+                new docTypeRef_RequestedPackagesType(
+                    self::PACKAGE_WEIGHT,
+                    new docTypeRef_DimensionsType(self::PACKAGE_LENGTH, self::PACKAGE_WIDTH, self::PACKAGE_HEIGHT),
+                    '1',
+                    1,
+                    'No Description'
+                )
+            )
+        );
+
+        if (null !== $shipmentRequest->getSpecialPickupInstruction()) {
+            $requestedShipment->setSpecialPickupInstruction($shipmentRequest->getSpecialPickupInstruction());
+        }
+
+        if (null !== $shipmentRequest->getPickupLocation()) {
+            $requestedShipment->setPickupLocation($shipmentRequest->getPickupLocation());
+        }
+
+        if ($shipTimestamp instanceof \DateTimeImmutable) {
+            $pickupLocationCloseTime = $shipTimestamp->modify('+91 minutes');
+        } else {
+            $pickupLocationCloseTime = \DateTimeImmutable::createFromMutable($shipTimestamp)->modify('+91 minutes');
+        }
+
+        $requestedShipment->setPickupLocationCloseTime($pickupLocationCloseTime->format('H:i'));
+
+        $request = new ProcessShipmentRequestType($requestedShipment);
+
+        $shipmentDetailType = $webservice->createShipmentRequest($request);
+
+        return $shipmentDetailType;
+    }
+    
+    /**
      * This should only be done if the pickup type is something other than PickupType::Regular.
      *
      * @param ShipmentRequest $shipmentRequest


### PR DESCRIPTION
Namely add an example for booking a shipment but also adding a nonsense-value for `PackageContentDescription`